### PR TITLE
Add `--hide-test` option.

### DIFF
--- a/arg.go
+++ b/arg.go
@@ -15,9 +15,10 @@ var (
 )
 
 type options struct {
-	path    string
-	ignore  []string
-	showAll bool
+	path     string
+	ignore   []string
+	showAll  bool
+	hideTest bool
 }
 
 func parseArgs() *options {
@@ -29,6 +30,7 @@ func parseArgs() *options {
 	flag.BoolVarP(&flagVersion, "version", "v", false, "Show version and build info and exit")
 	flag.StringArrayVarP(&o.ignore, "ignore", "", []string{}, "Ignore path to show if a given string would match")
 	flag.BoolVarP(&o.showAll, "show-all", "a", false, "Show all stuff")
+	flag.BoolVarP(&o.hideTest, "hide-test", "t", false, "Hide contents of test files")
 
 	flag.Parse()
 

--- a/builder.go
+++ b/builder.go
@@ -120,22 +120,29 @@ func walkProcess(arg *walkerArgs) error {
 }
 
 func getFileInfo(n *pt.N, arg *walkerArgs) (*pt.N, error) {
+	fiArgs := &fileinfo.Args{
+		FilePath: arg.filePath,
+		ShowAll:  arg.o.showAll,
+		HideTest: arg.o.hideTest,
+	}
+
 	if filepath.Ext(arg.filePath) == ".go" {
-		fi, err := fileinfo.GoInfo(arg.filePath, arg.o.showAll)
+		fi, err := fileinfo.GoInfo(fiArgs)
 		if err != nil {
 			return nil, err
 		}
-		n.Icon(fi.Icon).
-			Tag(fi.Tag).
-			Descriptions(fi.Descriptions)
+		n.Icon(fi.Icon).Tag(fi.Tag)
+		if !arg.o.hideTest || !strings.HasSuffix(filepath.Base(arg.filePath), "_test.go") {
+			n.Descriptions(fi.Descriptions)
+		}
 	} else if filepath.Base(arg.filePath) == "go.mod" {
-		fi, err := fileinfo.GoModInfo(arg.filePath, arg.o.showAll)
+		fi, err := fileinfo.GoModInfo(fiArgs)
 		if err != nil {
 			return nil, err
 		}
 		n.Tag(fi.Tag)
 	} else if filepath.Base(arg.filePath) == "LICENSE" {
-		fi, err := fileinfo.LicenseInfo(arg.filePath, arg.o.showAll)
+		fi, err := fileinfo.LicenseInfo(fiArgs)
 		if err != nil {
 			return nil, err
 		}

--- a/fileinfo/fileinfo.go
+++ b/fileinfo/fileinfo.go
@@ -5,3 +5,9 @@ type FileInfo struct {
 	Tag          string
 	Descriptions []string
 }
+
+type Args struct {
+	FilePath string
+	ShowAll  bool
+	HideTest bool
+}

--- a/fileinfo/go.go
+++ b/fileinfo/go.go
@@ -23,9 +23,9 @@ type organizer struct {
 }
 
 // GoInfo provides golang file *.go info
-func GoInfo(filepath string, showAll bool) (*FileInfo, error) {
+func GoInfo(args *Args) (*FileInfo, error) {
 	fset := token.NewFileSet()
-	fileAst, err := parser.ParseFile(fset, filepath, nil, 0)
+	fileAst, err := parser.ParseFile(fset, args.FilePath, nil, 0)
 	if err != nil {
 		return &FileInfo{}, err
 	}
@@ -58,10 +58,15 @@ func GoInfo(filepath string, showAll bool) (*FileInfo, error) {
 		return true
 	})
 
+	descr := []string{}
+	if !args.HideTest || !strings.HasSuffix(args.FilePath, "_test.go") {
+		descr = *buildDescriptions(&i, args)
+	}
+
 	return &FileInfo{
 		Icon:         "*",
 		Tag:          fileAst.Name.String(),
-		Descriptions: *buildDescriptions(&i, showAll),
+		Descriptions: descr,
 	}, nil
 }
 
@@ -106,24 +111,24 @@ func goInfoProcessIdent(o *ast.Object, i *organizer) {
 	}
 }
 
-func buildDescriptions(i *organizer, showAll bool) *[]string {
+func buildDescriptions(i *organizer, args *Args) *[]string {
 	descriptions := []string{}
 	if len(i.structs) > 0 {
 		descriptions = append(descriptions, "Struct: "+strings.Join(i.structs, ", "))
 	}
-	if showAll && len(i.privateStructs) > 0 {
+	if args.ShowAll && len(i.privateStructs) > 0 {
 		descriptions = append(descriptions, "struct: "+strings.Join(i.privateStructs, ", "))
 	}
 	if len(i.functions) > 0 {
 		descriptions = append(descriptions, "Func: "+strings.Join(i.functions, ", "))
 	}
-	if showAll && len(i.privateFunctions) > 0 {
+	if args.ShowAll && len(i.privateFunctions) > 0 {
 		descriptions = append(descriptions, "func: "+strings.Join(i.privateFunctions, ", "))
 	}
 	if len(i.constants) > 0 {
 		descriptions = append(descriptions, "Const: "+strings.Join(i.constants, ", "))
 	}
-	if showAll && len(i.privateConstants) > 0 {
+	if args.ShowAll && len(i.privateConstants) > 0 {
 		descriptions = append(descriptions, "const: "+strings.Join(i.privateConstants, ", "))
 	}
 

--- a/fileinfo/gomod.go
+++ b/fileinfo/gomod.go
@@ -7,8 +7,8 @@ import (
 )
 
 // GoModInfo provides go.mod file info: specified go version
-func GoModInfo(filepath string, showAll bool) (*FileInfo, error) {
-	file, err := os.Open(filepath)
+func GoModInfo(args *Args) (*FileInfo, error) {
+	file, err := os.Open(args.FilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/fileinfo/license.go
+++ b/fileinfo/license.go
@@ -7,8 +7,8 @@ import (
 )
 
 // LicenseInfo provides LICENSE file info
-func LicenseInfo(filepath string, showAll bool) (*FileInfo, error) {
-	file, err := os.Open(filepath)
+func LicenseInfo(args *Args) (*FileInfo, error) {
+	file, err := os.Open(args.FilePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If this `--hide-test` option is set, then golang test files (*_test.go) will be shown in tree, but any contents of these test files won't be picked up. These are hidden.